### PR TITLE
Change 'relationshipPriorityChanged' to 'modelChanged'

### DIFF
--- a/app/src/main/java/co/ello/android/ello/controllers/relationship/RelationshipController.kt
+++ b/app/src/main/java/co/ello/android/ello/controllers/relationship/RelationshipController.kt
@@ -9,8 +9,8 @@ class RelationshipController(val queue: Queue) {
         launch(UI) {
             val result = API().updateRelationship(userId = userId, relationship = next).enqueue(queue)
             when (result) {
-                is Success -> App.eventBus.post(RelationshipPriorityChanged(userId = userId, priority = next))
-                is Failure -> prev?.let { App.eventBus.post(RelationshipPriorityChanged(userId = userId, priority = it)) }
+                is Success -> App.eventBus.post(ModelChanged(type = MappingType.UsersType, id = userId, property = Model.Property.relationshipPriority, value = next))
+                is Failure -> prev?.let { App.eventBus.post(ModelChanged(type = MappingType.UsersType, id = userId, property = Model.Property.relationshipPriority, value = it)) }
             }
         }
 

--- a/app/src/main/java/co/ello/android/ello/events/Events.kt
+++ b/app/src/main/java/co/ello/android/ello/events/Events.kt
@@ -3,4 +3,10 @@ package co.ello.android.ello
 
 sealed class Event
 
-data class RelationshipPriorityChanged(val userId: String, val priority: RelationshipPriority) : Event()
+data class ModelChanged(
+    val type: MappingType,
+    val id: String,
+    val property: Model.Property,
+    val value: Any) : Event() {
+
+}

--- a/app/src/main/java/co/ello/android/ello/model/Activity.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Activity.kt
@@ -12,6 +12,8 @@ data class Activity(
     ) : Model() {
 
     val subject: Model? get() = getLinkObject("subject")
+    override val identifier = Parser.Identifier(id = id, table = MappingType.ActivitiesType)
+    override fun update(property: Property, value: Any) {}
 
     enum class Kind(val value: String) {
         NewFollowerPost("new_follower_post"), // someone started following you

--- a/app/src/main/java/co/ello/android/ello/model/AmazonCredentials.kt
+++ b/app/src/main/java/co/ello/android/ello/model/AmazonCredentials.kt
@@ -9,4 +9,7 @@ data class AmazonCredentials(
     val policy: String,
     val prefix: String,
     val signature: String
-    ) : Model()
+    ) : Model() {
+    override val identifier = null
+    override fun update(property: Property, value: Any) {}
+}

--- a/app/src/main/java/co/ello/android/ello/model/Announcement.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Announcement.kt
@@ -13,6 +13,9 @@ data class Announcement(
     val image: Asset?
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = id, table = MappingType.AnnouncementsType)
+    override fun update(property: Property, value: Any) {}
+
     val preferredAttachment: Attachment? get() = image?.hdpi
     val imageURL: URL? get() = preferredAttachment?.url
 

--- a/app/src/main/java/co/ello/android/ello/model/ArtistInvite.kt
+++ b/app/src/main/java/co/ello/android/ello/model/ArtistInvite.kt
@@ -17,6 +17,9 @@ data class ArtistInvite(
     val closedAt: Date?
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = id, table = MappingType.ArtistInvitesType)
+    override fun update(property: Property, value: Any) {}
+
     var headerImage: Asset? = null
     var logoImage: Asset? = null
     var guide: List<Guide> = emptyList()

--- a/app/src/main/java/co/ello/android/ello/model/ArtistInviteSubmission.kt
+++ b/app/src/main/java/co/ello/android/ello/model/ArtistInviteSubmission.kt
@@ -8,6 +8,9 @@ data class ArtistInviteSubmission(
     val status: Status
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = id, table = MappingType.ArtistInviteSubmissionsType)
+    override fun update(property: Property, value: Any) {}
+
     enum class Status(val value: String) {
         Approved("approved"),
         Selected("selected"),

--- a/app/src/main/java/co/ello/android/ello/model/Asset.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Asset.kt
@@ -15,6 +15,9 @@ data class Asset(val id: String) : Model() {
         Regular
     }
 
+    override val identifier = Parser.Identifier(id = id, table = MappingType.AssetsType)
+    override fun update(property: Property, value: Any) {}
+
     var optimized: Attachment? = null
     var mdpi: Attachment? = null
     var hdpi: Attachment? = null

--- a/app/src/main/java/co/ello/android/ello/model/Asset.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Asset.kt
@@ -5,7 +5,6 @@ import java.net.URL
 
 
 data class Asset(val id: String) : Model() {
-
     enum class AttachmentType {
         Optimized,
         Mdpi,

--- a/app/src/main/java/co/ello/android/ello/model/Attachment.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Attachment.kt
@@ -8,6 +8,9 @@ data class Attachment(
     val url: URL
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = url.toString(), table = MappingType.AttachmentsType)
+    override fun update(property: Property, value: Any) {}
+
     var size: Int? = null
     var width: Int? = null
     var height: Int? = null

--- a/app/src/main/java/co/ello/android/ello/model/Attachment.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Attachment.kt
@@ -15,16 +15,4 @@ data class Attachment(
     var image: Image? = null
 
     val isGif: Boolean get() = type == "image/gif" || url.getPath().endsWith(".gif")
-
-    companion object {
-        fun fromJSON(json: JSON): Attachment {
-            val url = json["url"].url!!
-            val attachment = Attachment(url)
-            attachment.size = json["metadata"]["size"].int
-            attachment.width = json["metadata"]["width"].int
-            attachment.height = json["metadata"]["height"].int
-            attachment.type = json["metadata"]["type"].string
-            return attachment
-        }
-    }
 }

--- a/app/src/main/java/co/ello/android/ello/model/Badge.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Badge.kt
@@ -13,6 +13,9 @@ data class Badge(
     val imageURL: URL?
     ) : Model() {
 
+    override val identifier = null
+    override fun update(property: Property, value: Any) {}
+
     val isFeatured: Boolean get() = slug == "featured"
     var categories: List<Category>? = null
 

--- a/app/src/main/java/co/ello/android/ello/model/Category.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Category.kt
@@ -14,6 +14,9 @@ data class Category(
     val tileImage: Attachment?
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = id, table = MappingType.CategoriesType)
+    override fun update(property: Property, value: Any) {}
+
     val isMeta: Boolean get() = level == CategoryLevel.Meta
     val tileURL: URL? get() = tileImage?.url
     val visibleOnSeeMore: Boolean get() = level == CategoryLevel.Primary || level == CategoryLevel.Secondary

--- a/app/src/main/java/co/ello/android/ello/model/CategoryPost.kt
+++ b/app/src/main/java/co/ello/android/ello/model/CategoryPost.kt
@@ -13,6 +13,9 @@ data class CategoryPost(
     val removedAt: Date
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = id, table = MappingType.CategoryPostsType)
+    override fun update(property: Property, value: Any) {}
+
     val category: Category? get() { return getLinkObject("category") }
     val submittedBy: User? get() { return getLinkObject("submittedBy") }
     val featuredBy: User? get() { return getLinkObject("featuredBy") }

--- a/app/src/main/java/co/ello/android/ello/model/Comment.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Comment.kt
@@ -12,6 +12,9 @@ data class Comment(
     val summary: List<Regionable>
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = id, table = MappingType.CommentsType)
+    override fun update(property: Property, value: Any) {}
+
     val assets: List<Asset> get() = getLinkArray("assets")
     val author: User? get() = getLinkObject("author")
     val parentPost: Post? get() = getLinkObject("parent_post")

--- a/app/src/main/java/co/ello/android/ello/model/Credentials.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Credentials.kt
@@ -5,4 +5,7 @@ data class Credentials(
     val accessToken: String,
     val refreshToken: String?,
     val isAnonymous: Boolean
-) : Model()
+) : Model() {
+    override val identifier = null
+    override fun update(property: Property, value: Any) {}
+}

--- a/app/src/main/java/co/ello/android/ello/model/Editorial.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Editorial.kt
@@ -14,6 +14,9 @@ data class Editorial(
     val path: URL?
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = id, table = MappingType.EditorialsType)
+    override fun update(property: Property, value: Any) {}
+
     data class JoinInfo(
         val email: String?,
         val username: String?,

--- a/app/src/main/java/co/ello/android/ello/model/Love.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Love.kt
@@ -12,6 +12,9 @@ data class Love(
     val userId: String
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = id, table = MappingType.LovesType)
+    override fun update(property: Property, value: Any) {}
+
     val post: Post? get() = getLinkObject("post")
     val user: User? get() = getLinkObject("user")
 

--- a/app/src/main/java/co/ello/android/ello/model/MappingType.kt
+++ b/app/src/main/java/co/ello/android/ello/model/MappingType.kt
@@ -16,22 +16,24 @@ sealed class MappingType {
     }
 
     object ActivitiesType : MappingType(name = "activities", singularKey = "activity")
-    object AmazonCredentialsType : MappingType(name = "credentials", singularKey = "credentials")
     object AnnouncementsType : MappingType(name = "announcements", singularKey = "announcement")
     object ArtistInvitesType : MappingType(name = "artist_invites", singularKey = "artistInvite")
     object ArtistInviteSubmissionsType : MappingType(name = "artist_invite_submissions", singularKey = "artistInviteSubmission")
     object AssetsType : MappingType(name = "assets", singularKey = "asset", parser = { AssetParser() })
+    object AttachmentsType : MappingType(name = "attachments", singularKey = "attachment")
     object AutoCompleteResultType : MappingType(name = "autocomplete_results", singularKey = "autocompleteResult")
     object AvailabilityType : MappingType(name = "availability", singularKey = "availability", pluralKey = "availabilities")
     object CategoriesType : MappingType(name = "categories", singularKey = "category", parser = { CategoryParser() })
     object CategoryPostsType : MappingType(name = "category_posts", singularKey = "categoryPost", parser = { CategoryPostParser() })
+    object CredentialsType : MappingType(name = "credentials", singularKey = "credential", parser = { CredentialsParser(isAnonymous = false) })
     object CommentsType : MappingType(name = "comments", singularKey = "comment", parser = { CommentParser() })
     object DynamicSettingsType : MappingType(name = "settings", singularKey = "setting")
-    object Editorials : MappingType(name = "editorials", singularKey = "editorial", parser = { EditorialParser() })
+    object EditorialsType : MappingType(name = "editorials", singularKey = "editorial", parser = { EditorialParser() })
     object ErrorsType : MappingType(name = "errors", singularKey = "error")
     object ErrorType : MappingType(name = "error", singularKey = "error", pluralKey = "errors")
     object LovesType : MappingType(name = "loves", singularKey = "love")
     object NoContentType : MappingType(name = "204", singularKey = "204")
+    object NotificationsType : MappingType(name = "notifications", singularKey = "notification")
     object PageHeadersType : MappingType(name = "page_headers", singularKey = "pageHeader", parser = { PageHeaderParser() })
     object PostsType : MappingType(name = "posts", singularKey = "post", parser = { PostParser() })
     object ProfilesType : MappingType(name = "profiles", singularKey = "profile", parser = { ProfileParser() })
@@ -43,7 +45,7 @@ sealed class MappingType {
     companion object {
         fun create(value: String): MappingType? = when (value) {
             "activities"                -> MappingType.ActivitiesType
-            "credentials"               -> MappingType.AmazonCredentialsType
+            "credentials"               -> MappingType.CredentialsType
             "announcements"             -> MappingType.AnnouncementsType
             "artist_invites"            -> MappingType.ArtistInvitesType
             "artist_invite_submissions" -> MappingType.ArtistInviteSubmissionsType
@@ -54,7 +56,7 @@ sealed class MappingType {
             "category_posts"            -> MappingType.CategoryPostsType
             "comments"                  -> MappingType.CommentsType
             "settings"                  -> MappingType.DynamicSettingsType
-            "editorials"                -> MappingType.Editorials
+            "editorials"                -> MappingType.EditorialsType
             "errors"                    -> MappingType.ErrorsType
             "error"                     -> MappingType.ErrorType
             "loves"                     -> MappingType.LovesType

--- a/app/src/main/java/co/ello/android/ello/model/Model.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Model.kt
@@ -15,10 +15,6 @@ abstract class Model {
 
     enum class Property {
         relationshipPriority;
-
-        fun matches(model: Model, value: Any): Boolean = when (this) {
-            relationshipPriority -> (model as? User)?.relationshipPriority == value as RelationshipPriority
-        }
     }
 
     abstract fun update(property: Property, value: Any)

--- a/app/src/main/java/co/ello/android/ello/model/Model.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Model.kt
@@ -1,7 +1,7 @@
 package co.ello.android.ello
 
 
-open class Model {
+abstract class Model {
     sealed class Link {
         data class One(val id: String, val type: MappingType) : Link()
         data class Many(val ids: List<String>, val type: MappingType) : Link()
@@ -10,6 +10,18 @@ open class Model {
     }
 
     var links: MutableMap<String, Model.Link> = mutableMapOf()
+
+    abstract val identifier: Parser.Identifier?
+
+    enum class Property {
+        relationshipPriority;
+
+        fun matches(model: Model, value: Any): Boolean = when (this) {
+            relationshipPriority -> (model as? User)?.relationshipPriority == value as RelationshipPriority
+        }
+    }
+
+    abstract fun update(property: Property, value: Any)
 
     inline fun <reified T: Model> getLinkObject(key: String): T? {
         val link = links[key] ?: return null

--- a/app/src/main/java/co/ello/android/ello/model/Notification.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Notification.kt
@@ -7,6 +7,9 @@ data class Notification(
     val activity: Activity
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = activity.id, table = MappingType.NotificationsType)
+    override fun update(property: Property, value: Any) {}
+
     var author: User? = null
     var postId: String? = null
 

--- a/app/src/main/java/co/ello/android/ello/model/PageHeader.kt
+++ b/app/src/main/java/co/ello/android/ello/model/PageHeader.kt
@@ -16,6 +16,9 @@ data class PageHeader(
     val kind: Kind
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = id, table = MappingType.PageHeadersType)
+    override fun update(property: Property, value: Any) {}
+
     val user: User? get() = getLinkObject("user")
 
     enum class Kind(val value: String) {

--- a/app/src/main/java/co/ello/android/ello/model/Post.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Post.kt
@@ -21,6 +21,9 @@ data class Post(
     val repostContent: List<Regionable>
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = id, table = MappingType.PostsType)
+    override fun update(property: Property, value: Any) {}
+
     var artistInviteId: String? = null
     var viewsCount: Int? = null
     var commentsCount: Int? = null

--- a/app/src/main/java/co/ello/android/ello/model/Profile.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Profile.kt
@@ -50,6 +50,9 @@ data class Profile(
     val gaUniqueId: String?
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = id, table = MappingType.ProfilesType)
+    override fun update(property: Model.Property, value: Any) {}
+
     sealed class CreatorType {
         object None : CreatorType()
         object Fan : CreatorType()

--- a/app/src/main/java/co/ello/android/ello/model/Relationship.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Relationship.kt
@@ -9,6 +9,9 @@ data class Relationship(
     val subjectId: String
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = id, table = MappingType.RelationshipsType)
+    override fun update(property: Property, value: Any) {}
+
     val owner: User? get() = getLinkObject("owner")
     val subject: User? get() = getLinkObject("subject")
 }

--- a/app/src/main/java/co/ello/android/ello/model/User.kt
+++ b/app/src/main/java/co/ello/android/ello/model/User.kt
@@ -18,6 +18,12 @@ data class User(
     val isHireable: Boolean
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = id, table = MappingType.UsersType)
+    override fun update(property: Property, value: Any) = when (property) {
+        Model.Property.relationshipPriority -> relationshipPriority = value as RelationshipPriority
+        else -> {}
+    }
+
     var avatar: Asset? = null
     var coverImage: Asset? = null
 

--- a/app/src/main/java/co/ello/android/ello/model/Watch.kt
+++ b/app/src/main/java/co/ello/android/ello/model/Watch.kt
@@ -11,6 +11,9 @@ data class Watch(
     val userId: String
     ) : Model() {
 
+    override val identifier = Parser.Identifier(id = id, table = MappingType.WatchesType)
+    override fun update(property: Property, value: Any) {}
+
     val post: Post? get() =  getLinkObject("post")
     val user: User? get() =  getLinkObject("user")
 

--- a/app/src/main/java/co/ello/android/ello/model/regions/EmbedRegion.kt
+++ b/app/src/main/java/co/ello/android/ello/model/regions/EmbedRegion.kt
@@ -10,6 +10,9 @@ data class EmbedRegion(
     val thumbnailLargeUrl: URL?
     ) : Model(), Regionable {
 
+    override val identifier = null
+    override fun update(property: Property, value: Any) {}
+
     override var isRepost: Boolean = false
     override val kind: RegionKind get() = RegionKind.Embed
 

--- a/app/src/main/java/co/ello/android/ello/model/regions/ImageRegion.kt
+++ b/app/src/main/java/co/ello/android/ello/model/regions/ImageRegion.kt
@@ -8,6 +8,9 @@ data class ImageRegion(
     val buyButtonURL: URL?
     ) : Model(), Regionable {
 
+    override val identifier = null
+    override fun update(property: Property, value: Any) {}
+
     override var isRepost: Boolean = false
     override val kind: RegionKind get() = RegionKind.Image
 

--- a/app/src/main/java/co/ello/android/ello/model/regions/TextRegion.kt
+++ b/app/src/main/java/co/ello/android/ello/model/regions/TextRegion.kt
@@ -5,6 +5,9 @@ data class TextRegion(
     val content: String
     ) : Model(), Regionable {
 
+    override val identifier = null
+    override fun update(property: Property, value: Any) {}
+
     override var isRepost: Boolean = false
     override val kind: RegionKind get() = RegionKind.Text
 }

--- a/app/src/main/java/co/ello/android/ello/network/API.kt
+++ b/app/src/main/java/co/ello/android/ello/network/API.kt
@@ -133,6 +133,16 @@ class API {
             .setBody(Fragments.postStreamBody)
     }
 
+    fun userLoves(username: String, before: String? = null): GraphQLRequest<Pair<PageConfig, List<Love>>> {
+        return GraphQLRequest<Pair<PageConfig, List<Love>>>("userLoveStream")
+            .parser { PageParser<Love>("loves", LoveParser()).parse(it) }
+            .setVariables(
+                GraphQLRequest.Variable.string("username", username),
+                GraphQLRequest.Variable.optionalString("before", before)
+            )
+            .setBody(Fragments.loveStreamBody)
+    }
+
     fun updateRelationship(userId: String, relationship: RelationshipPriority): ElloRequest<Relationship> {
         val path = "/api/v2/users/$userId/add/${relationship.value}"
         val elloRequest = ElloRequest<Relationship>(ElloRequest.Method.POST, path)

--- a/app/src/main/java/co/ello/android/ello/network/Fragments.kt
+++ b/app/src/main/java/co/ello/android/ello/network/Fragments.kt
@@ -142,6 +142,13 @@ class Fragments {
               assets { ...assetProps }
             }
             """, needs = listOf(contentProps, authorProps, assetProps))
+        val loveDetails = Fragments("""
+            fragment loveDetails on Love {
+                id
+                post { ...postDetails }
+                user { id }
+            }
+            """, needs: listOf(postDetails))
 
         val userDetails = Fragments("""
             fragment userDetails on User {
@@ -233,6 +240,12 @@ class Fragments {
         val userBody = Fragments("""
             ...userDetails
             """, needs = listOf(userDetails))
+        val loveStreamBody = Fragments("""
+            next isLastPage
+            loves {
+                ...loveDetails
+            }
+            """, needs: listOf(loveDetails))
     }
 
     val dependencies: List<Fragments> get() {

--- a/app/src/main/java/co/ello/android/ello/network/GraphQLRequest.kt
+++ b/app/src/main/java/co/ello/android/ello/network/GraphQLRequest.kt
@@ -17,23 +17,22 @@ class GraphQLRequest<T>(
     object CancelledRequest : Throwable()
     object RequestNull : Throwable()
 
-    sealed class Variable {
+    sealed class Variable(val type: String) {
         abstract val name: String
-        abstract val type: String
         abstract val value: Any?
 
-        data class string(override val name: String         , override val value: String)   : Variable() { override val type: String get() { return "String!"}}
-        data class optionalString(override val name: String , override val value: String?)  : Variable() { override val type: String get() { return "String" }}
-        data class id(override val name: String             , override val value: String)   : Variable() { override val type: String get() { return "ID!"}}
-        data class optionalID(override val name: String     , override val value: String?)  : Variable() { override val type: String get() { return "ID" }}
-        data class int(override val name: String            , override val value: Int)      : Variable() { override val type: String get() { return "Int!"   }}
-        data class optionalInt(override val name: String    , override val value: Int?)     : Variable() { override val type: String get() { return "Int"    }}
-        data class float(override val name: String          , override val value: Float)    : Variable() { override val type: String get() { return "Float!" }}
-        data class optionalFloat(override val name: String  , override val value: Float?)   : Variable() { override val type: String get() { return "Float"  }}
-        data class boolean(override val name: String        , override val value: Boolean)  : Variable() { override val type: String get() { return "Bool!"  }}
-        data class optionalBoolean(override val name: String, override val value: Boolean?) : Variable() { override val type: String get() { return "Bool"   }}
-        data class enum(override val name: String           , override val value: String, val typeName: String) : Variable() { override val type: String get() { return "$typeName!" }}
-        data class optionalEnum(override val name: String   , override val value: String?, val typeName: String) : Variable() { override val type: String get() { return typeName }}
+        data class string(override val name: String         , override val value: String)   : Variable("String!")
+        data class optionalString(override val name: String , override val value: String?)  : Variable("String")
+        data class id(override val name: String             , override val value: String)   : Variable("ID!")
+        data class optionalID(override val name: String     , override val value: String?)  : Variable("ID")
+        data class int(override val name: String            , override val value: Int)      : Variable("Int!")
+        data class optionalInt(override val name: String    , override val value: Int?)     : Variable("Int")
+        data class float(override val name: String          , override val value: Float)    : Variable("Float!")
+        data class optionalFloat(override val name: String  , override val value: Float?)   : Variable("Float")
+        data class boolean(override val name: String        , override val value: Boolean)  : Variable("Bool!")
+        data class optionalBoolean(override val name: String, override val value: Boolean?) : Variable("Bool")
+        data class enum(override val name: String           , override val value: String, typeName: String) : Variable("$typeName!")
+        data class optionalEnum(override val name: String   , override val value: String?, typeName: String) : Variable(typeName)
     }
 
     private val headers = HashMap<String, String>()

--- a/app/src/main/java/co/ello/android/ello/network/parsers/AssetParser.kt
+++ b/app/src/main/java/co/ello/android/ello/network/parsers/AssetParser.kt
@@ -19,7 +19,7 @@ class AssetParser : IdParser(table = MappingType.AssetsType) {
         )
         for ((attachmentJSON, type) in attachments) {
             if (attachmentJSON["url"].string == null) continue
-            asset.replace(type = type, withAttachment = Attachment.fromJSON(attachmentJSON))
+            asset.replace(type = type, withAttachment = AttachmentParser().parse(attachmentJSON))
         }
 
         return asset

--- a/app/src/main/java/co/ello/android/ello/network/parsers/AttachmentParser.kt
+++ b/app/src/main/java/co/ello/android/ello/network/parsers/AttachmentParser.kt
@@ -1,0 +1,14 @@
+package co.ello.android.ello
+
+
+class AttachmentParser : IdParser(table = MappingType.AttachmentsType) {
+    override fun parse(json: JSON): Attachment {
+        val url = json["url"].url!!
+        val attachment = Attachment(url)
+        attachment.type = json["metadata"]["type"].string
+        attachment.size = json["metadata"]["size"].int
+        attachment.width = json["metadata"]["width"].int
+        attachment.height = json["metadata"]["height"].int
+        return attachment
+    }
+}

--- a/app/src/main/java/co/ello/android/ello/network/parsers/CategoryParser.kt
+++ b/app/src/main/java/co/ello/android/ello/network/parsers/CategoryParser.kt
@@ -13,7 +13,7 @@ class CategoryParser : IdParser(table = MappingType.CategoriesType) {
             allowInOnboarding = json["allowInOnboarding"].boolean ?: true,
             isCreatorType = json["isCreatorType"].boolean ?: true,
             level = level,
-            tileImage = Attachment.fromJSON(json["tileImage"]["large"])
+            tileImage = AttachmentParser().parse(json["tileImage"]["large"])
             )
 
         category.mergeLinks(json["links"])

--- a/app/src/main/java/co/ello/android/ello/network/parsers/EditorialParser.kt
+++ b/app/src/main/java/co/ello/android/ello/network/parsers/EditorialParser.kt
@@ -1,9 +1,7 @@
 package co.ello.android.ello
 
-import java.net.URL
 
-
-class EditorialParser : IdParser(table = MappingType.Editorials) {
+class EditorialParser : IdParser(table = MappingType.EditorialsType) {
     init {
         linkObject(MappingType.PostsType)
     }

--- a/app/src/main/java/co/ello/android/ello/stream/StreamController.kt
+++ b/app/src/main/java/co/ello/android/ello/stream/StreamController.kt
@@ -93,9 +93,8 @@ class StreamController(a: AppActivity)
             val model = item.model ?: continue
             val identifier = model.identifier ?: continue
             if (event.type != identifier.table || event.id != identifier.id)  continue
-            if (event.property.matches(model, event.value))  continue
-            model.update(event.property, event.value)
             adapter.notifyItemChanged(index)
+            model.update(event.property, event.value)
         }
     }
 

--- a/app/src/main/java/co/ello/android/ello/stream/StreamController.kt
+++ b/app/src/main/java/co/ello/android/ello/stream/StreamController.kt
@@ -88,11 +88,13 @@ class StreamController(a: AppActivity)
     }
 
     @Subscribe
-    fun relationshipChanged(event: RelationshipPriorityChanged) {
+    fun modelChanged(event: ModelChanged) {
         for ((index, item) in adapter.items.withIndex()) {
-            val user = item.model as? User ?: continue
-            if (user.id != event.userId || user.relationshipPriority == event.priority)  continue
-            user.relationshipPriority = event.priority
+            val model = item.model ?: continue
+            val identifier = model.identifier ?: continue
+            if (event.type != identifier.table || event.id != identifier.id)  continue
+            if (event.property.matches(model, event.value))  continue
+            model.update(event.property, event.value)
             adapter.notifyItemChanged(index)
         }
     }

--- a/app/src/main/java/co/ello/android/ello/views/stream/PostEmbedCell.kt
+++ b/app/src/main/java/co/ello/android/ello/views/stream/PostEmbedCell.kt
@@ -62,7 +62,6 @@ class PostEmbedCell(parent: ViewGroup, isComment: Boolean)
 
     private fun playButtonTapped() {
         val streamController = streamController ?: return
-        val item = streamCellItem ?: return
         val url = url ?: return
 
         streamController.streamTappedURL(url)

--- a/app/src/main/java/co/ello/android/ello/views/stream/PostImageCell.kt
+++ b/app/src/main/java/co/ello/android/ello/views/stream/PostImageCell.kt
@@ -2,6 +2,7 @@ package co.ello.android.ello
 
 import android.support.constraint.ConstraintLayout
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import java.net.URL
@@ -14,6 +15,7 @@ class PostImageCell(parent: ViewGroup, isComment: Boolean)
         else R.layout.post_image_cell, parent, false))
 
 {
+    private val loadingView: View = itemView.findViewById(R.id.loadingView)
     private val imageView: ImageView = itemView.findViewById(R.id.imageView)
     private var aspectRatio: Float? = null
 
@@ -29,6 +31,8 @@ class PostImageCell(parent: ViewGroup, isComment: Boolean)
     fun config(value: Config) {
         aspectRatio = null
         streamCellItem?.height?.let { assignHeight(it) }
+
+        loadingView.visibility = View.VISIBLE
 
         if (value.isGif) {
             imageView.setImageURL(null)
@@ -46,6 +50,7 @@ class PostImageCell(parent: ViewGroup, isComment: Boolean)
     }
 
     private fun calculateHeight() {
+        loadingView.visibility = View.INVISIBLE
         val imageWidth = imageView.drawable.intrinsicWidth
         val imageHeight = imageView.drawable.intrinsicHeight
         if (imageWidth > 0 && imageHeight > 0) {

--- a/app/src/main/res/layout/comment_image_cell.xml
+++ b/app/src/main/res/layout/comment_image_cell.xml
@@ -6,6 +6,20 @@
     android:layout_height="match_parent"
     android:layout_marginLeft="40dp">
 
+    <View
+        android:id="@+id/loadingView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginBottom="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
+        android:background="@color/greyA"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <ImageView
         android:id="@+id/imageView"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/post_image_cell.xml
+++ b/app/src/main/res/layout/post_image_cell.xml
@@ -5,6 +5,20 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <View
+        android:id="@+id/loadingView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginBottom="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
+        android:background="@color/greyA"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <ImageView
         android:id="@+id/imageView"
         android:layout_width="match_parent"


### PR DESCRIPTION
Instead of sending specific 'BlaBlaChanged' events, we can use a generic "model changed event" and include the "table" (`MappingType`), id, property, and new value.  Then, in the listeners, we pass that update into all models that match the table/id, and refresh those cells.